### PR TITLE
Default config files for gem5 and dramsys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.sw[po]
 .vscode
 build/
 *~

--- a/configs/ips/memory/ddr.json
+++ b/configs/ips/memory/ddr.json
@@ -1,5 +1,9 @@
 {
   "size"  : "0x10000000",
   "vp_class": "memory/ddr",
-  "frequency": 100000000
+  "frequency": 100000000,
+  "tlm": {
+    "dramsys-config": "ddr3-example.xml",
+    "gem5-config": "config.ini"
+  }
 }


### PR DESCRIPTION
This is to be used with SystemC TLM-2.0 coupling.