### PR TITLE
replaced strange dashes with regular ones

### DIFF
--- a/configs/ips/fll/fll_v1.json
+++ b/configs/ips/fll/fll_v1.json
@@ -80,7 +80,7 @@
           "bit": 0,
           "width": 4,
           "access": "R/W",
-          "name": "FLL loop gain setting (default: 2^−8 = 1/256).",
+          "name": "FLL loop gain setting (default: 2^-8 = 1/256).",
           "desc": "When using normal mode, this defines the gain applied to the difference between the specified multiplication factor and the actual one, before it is provided to the loop filter."
         },
         "deassert_cycles": {

--- a/configs/ips/udma/udma_v2.json
+++ b/configs/ips/udma/udma_v2.json
@@ -167,7 +167,7 @@
         "CMD_SIZE": {
           "bit": 16,
           "width": 5,
-          "desc": "Size in bits of the command to send. The value written here is num bits – 1."
+          "desc": "Size in bits of the command to send. The value written here is num bits - 1."
         },
         "QPI": {
           "bit": 27,
@@ -188,7 +188,7 @@
         "CMD_SIZE": {
           "bit": 16,
           "width": 5,
-          "desc": "Size in bits of the address to send. The value written here is num bits – 1."
+          "desc": "Size in bits of the address to send. The value written here is num bits - 1."
         },
         "QPI": {
           "bit": 27,
@@ -241,7 +241,7 @@
         "DATA_SIZE": {
           "bit": 0,
           "width": 16,
-          "desc": "Number of bits to send (Max 64Kbits). The value written here is num bits – 1."
+          "desc": "Number of bits to send (Max 64Kbits). The value written here is num bits - 1."
         },
         "BYTE_ALIGN": {
           "bit": 26,
@@ -267,7 +267,7 @@
         "DATA_SIZE": {
           "bit": 0,
           "width": 16,
-          "desc": "Number of bits to receive (Max 64Kbits). The value written here is num bits – 1."
+          "desc": "Number of bits to receive (Max 64Kbits). The value written here is num bits - 1."
         },
         "BYTE_ALIGN": {
           "bit": 26,
@@ -341,7 +341,7 @@
         "STATUS_SIZE": {
           "bit": 16,
           "width": 4,
-          "desc": "Size in bits of the word to read. The value written here is num bits – 1."
+          "desc": "Size in bits of the word to read. The value written here is num bits - 1."
         },
         "CHECK_TYPE": {
           "bit": 24,
@@ -372,7 +372,7 @@
         "DATA_SIZE": {
           "bit": 0,
           "width": 16,
-          "desc": "Number of bits to send (Max 64Kbits). The value written here is num bits – 1."
+          "desc": "Number of bits to send (Max 64Kbits). The value written here is num bits - 1."
         },
         "BYTE_ALIGN": {
           "bit": 26,

--- a/configs/ips/udma/udma_v3.json
+++ b/configs/ips/udma/udma_v3.json
@@ -167,7 +167,7 @@
         "CMD_SIZE": {
           "bit": 16,
           "width": 5,
-          "desc": "Size in bits of the command to send. The value written here is num bits – 1."
+          "desc": "Size in bits of the command to send. The value written here is num bits - 1."
         },
         "QPI": {
           "bit": 27,
@@ -188,7 +188,7 @@
         "CMD_SIZE": {
           "bit": 16,
           "width": 5,
-          "desc": "Size in bits of the address to send. The value written here is num bits – 1."
+          "desc": "Size in bits of the address to send. The value written here is num bits - 1."
         },
         "QPI": {
           "bit": 27,
@@ -241,7 +241,7 @@
         "DATA_SIZE": {
           "bit": 0,
           "width": 16,
-          "desc": "Number of bits to send (Max 64Kbits). The value written here is num bits – 1."
+          "desc": "Number of bits to send (Max 64Kbits). The value written here is num bits - 1."
         },
         "BYTE_ALIGN": {
           "bit": 26,
@@ -267,7 +267,7 @@
         "DATA_SIZE": {
           "bit": 0,
           "width": 16,
-          "desc": "Number of bits to receive (Max 64Kbits). The value written here is num bits – 1."
+          "desc": "Number of bits to receive (Max 64Kbits). The value written here is num bits - 1."
         },
         "BYTE_ALIGN": {
           "bit": 26,
@@ -341,7 +341,7 @@
         "STATUS_SIZE": {
           "bit": 16,
           "width": 4,
-          "desc": "Size in bits of the word to read. The value written here is num bits – 1."
+          "desc": "Size in bits of the word to read. The value written here is num bits - 1."
         },
         "CHECK_TYPE": {
           "bit": 24,
@@ -372,7 +372,7 @@
         "DATA_SIZE": {
           "bit": 0,
           "width": 16,
-          "desc": "Number of bits to send (Max 64Kbits). The value written here is num bits – 1."
+          "desc": "Number of bits to send (Max 64Kbits). The value written here is num bits - 1."
         },
         "BYTE_ALIGN": {
           "bit": 26,


### PR DESCRIPTION
This prevents `decode()` errors in the Python scripts I got when I tried to build pulpissimo. 
I only searched and fixed the ones I encountered, maybe there are more in other files. 
There are also two different 'strange' dashes. The udma-file ones differ from the fll ones.

[related pulp-configs pull request](https://github.com/pulp-platform/archi/pull/20#issue-286085848)
